### PR TITLE
fixes to src and binding.byp to allow windows installation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,68 @@
             '-Wall'
           ],
         }],
+        ['OS=="win"', {
+            "variables": {
+                'ms_buildkit%': 'Z:/PATH/TO/MAPSERVER_BUILDKIT',
+                'ms_root%': 'Z:/PATH/TO/MAPSERVER'
+            },
+            "include_dirs" : [ 
+                "<(ms_root)/",
+                "<(ms_buildkit)/include/" 
+            ],
+            "libraries" : [
+                '<(ms_root)/mapserver_i.lib',
+                '<(ms_buildkit)/lib/gdal_i.lib',
+                '<(ms_buildkit)/lib/agg.lib',
+                '<(ms_buildkit)/lib/cairo.lib',
+                '<(ms_buildkit)/lib/cfitsio.lib',
+                '<(ms_buildkit)/lib/fontconfig.lib',
+                '<(ms_buildkit)/lib/freetype239.lib',
+                '<(ms_buildkit)/lib/freexl.lib',
+                '<(ms_buildkit)/lib/freexl_i.lib',
+                '<(ms_buildkit)/lib/fribidi.lib',
+                '<(ms_buildkit)/lib/ftgl.lib',
+                '<(ms_buildkit)/lib/gd.lib',
+                '<(ms_buildkit)/lib/gdal_i.lib',
+                '<(ms_buildkit)/lib/geos_c_i.lib',
+                '<(ms_buildkit)/lib/giflib.lib',
+                '<(ms_buildkit)/lib/hdf5dll.lib',
+                '<(ms_buildkit)/lib/iconv.lib',
+                '<(ms_buildkit)/lib/libcurl_imp.lib',
+                '<(ms_buildkit)/lib/libeay32.lib',
+                '<(ms_buildkit)/lib/libecwj2.lib',
+                '<(ms_buildkit)/lib/libexpat.lib',
+                '<(ms_buildkit)/lib/libfcgi.lib',
+                '<(ms_buildkit)/lib/libjbig.lib',
+                '<(ms_buildkit)/lib/libjpeg.lib',
+                '<(ms_buildkit)/lib/libming.lib',
+                '<(ms_buildkit)/lib/libmysql.lib',
+                '<(ms_buildkit)/lib/libpng.lib',
+                '<(ms_buildkit)/lib/libpq.lib',
+                '<(ms_buildkit)/lib/libpqdll.lib',
+                '<(ms_buildkit)/lib/libtiff_i.lib',
+                '<(ms_buildkit)/lib/libxml2.lib',
+                '<(ms_buildkit)/lib/minizip.lib',
+                '<(ms_buildkit)/lib/netcdf.lib',
+                '<(ms_buildkit)/lib/openjp2.lib',
+                '<(ms_buildkit)/lib/openjpeg.lib',
+                '<(ms_buildkit)/lib/openjpegstatic.lib',
+                '<(ms_buildkit)/lib/pdflib.lib',
+                '<(ms_buildkit)/lib/pixman-1.lib',
+                '<(ms_buildkit)/lib/poppler.lib',
+                '<(ms_buildkit)/lib/proj.lib',
+                '<(ms_buildkit)/lib/proj_i.lib',
+                '<(ms_buildkit)/lib/spatialite.lib',
+                '<(ms_buildkit)/lib/spatialite_i.lib',
+                '<(ms_buildkit)/lib/sqlite3_i.lib',
+                '<(ms_buildkit)/lib/ssleay32.lib',
+                '<(ms_buildkit)/lib/vld.lib',
+                '<(ms_buildkit)/lib/xerces-c_2.lib',
+                '<(ms_buildkit)/lib/zdll.lib',
+                '<(ms_buildkit)/lib/zlib.lib',
+                '<(ms_buildkit)/lib/proj.lib'
+            ]
+        }],
       ]
     }
   ]

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -311,7 +311,7 @@ Handle<Value> Map::MapservAsync(const Arguments& args) {
     } else if (Buffer::HasInstance(args[1])) {
       Local<Object> buffer = args[1]->ToObject();
       body = string(Buffer::Data(buffer), Buffer::Length(buffer));
-    } else if (!args[1]->IsNull() and !args[1]->IsUndefined()) {
+    } else if (!args[1]->IsNull() && !args[1]->IsUndefined()) {
       THROW_CSTR_ERROR(TypeError, "Argument 1 must be one of a string; buffer; null; undefined");
     }
 

--- a/src/node-mapservutil.c
+++ b/src/node-mapservutil.c
@@ -58,7 +58,7 @@ int wrap_loadParams(cgiRequestObj *request, char* (*getenv2)(const char*, void* 
 int updateMap(mapservObj *mapserv, mapObj *map) {
   int i, j;
 
-  if(!msLookupHashTable(&(map->web.validation), "immutable")) {
+  if(1 || !msLookupHashTable(&(map->web.validation), "immutable")) {
     /* check for any %variable% substitutions here, also do any map_ changes, we do this here so WMS/WFS  */
     /* services can take advantage of these "vendor specific" extensions */
     for(i=0; i<mapserv->request->NumParams; i++) {


### PR DESCRIPTION
I was able to manually build node-mapserv on a Windows 7 64 bits machine with the following fixes.

The binding.gyp requires 2 variables to be manually set before configuring: 

```
"variables": {
    'ms_buildkit%': 'Z:/PATH/TO/MAPSERVER_BUILDKIT',
    'ms_root%': 'Z:/PATH/TO/MAPSERVER'
},
```
