### PR TITLE
Fix cgi environment url parsing

### DIFF
--- a/lib/mapserv.js
+++ b/lib/mapserv.js
@@ -61,7 +61,7 @@ try {
  * for details of CGI environment variables.
  */
 function createCGIEnvironment(req, vars) {
-    var urlParts = url.parse(decodeURIComponent(req.url)), // parse the request url
+    var urlParts = url.parse(req.url), // parse the request url
         host = req.headers.host.split(':'),
         env = {
             // Server specific variables:
@@ -73,8 +73,8 @@ function createCGIEnvironment(req, vars) {
             SERVER_PROTOCOL: 'HTTP/' + req.httpVersion,
             SERVER_PORT: host[1],
             REQUEST_METHOD: req.method,
-            PATH_INFO: urlParts.pathname || '/',
-            PATH_TRANSLATED: path.resolve(path.join('.', urlParts.pathname)),
+            PATH_INFO: decodeURIComponent(urlParts.pathname) || '/',
+            PATH_TRANSLATED: path.resolve(path.join('.', decodeURIComponent(urlParts.pathname))),
             SCRIPT_NAME: '/',
             QUERY_STRING: urlParts.query || '',
             REMOTE_ADDR: req.connection.remoteAddress


### PR DESCRIPTION
We had an issue when trying to use SLD with MapServer via node-mapserv.  The SLD_BODY parameter value, which is an encoded SLD XML string, seems to be decoded before being sent to MapServer.  A friend of mine, who is unfamiliar with Github, proposed the following fix, which solves the issue.

What do you think ?
